### PR TITLE
check for :message_queue_len instead for :messages which gives nil

### DIFF
--- a/lib/stream.ex
+++ b/lib/stream.ex
@@ -112,7 +112,7 @@ defmodule Torrent.Stream do
 
   def process_communication(socket, info_structs) do
     cond do
-      length(Process.info(self)[:messages]) > 0 ->
+      Process.info(self(), :message_queue_len) |> elem(1) > 0 ->
         receive do
           { :received, index } ->
             # IO.puts "sending have message"


### PR DESCRIPTION
When running Torrent.init, I was getting: 

`** (ArgumentError) argument error
    :erlang.length(nil)
    (torrent) lib/stream.ex:115: Torrent.Stream.process_communication/2
    (torrent) lib/stream.ex:141: Torrent.Stream.pipe_message/2
    (elixir) lib/task/supervised.ex:89: Task.Supervised.do_apply/2
    (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3`

It was because `Process.info(self)[:messages]` was nil, using `Process.info(self(), :message_queue_len)` seems so solve the issue.